### PR TITLE
Move MX-1 nuclear reactor down to preceding CTT node

### DIFF
--- a/GameData/NearFutureElectrical/Patches/NFElectricalCommunityTechTree.cfg
+++ b/GameData/NearFutureElectrical/Patches/NFElectricalCommunityTechTree.cfg
@@ -10,7 +10,7 @@
 }
 @PART[reactor-125]:NEEDS[CommunityTechTree]:FOR[NearFutureElectrical]
 {
-	@TechRequired = advNuclearPower
+	@TechRequired = largeNuclearPower
 }
 @PART[reactor-0625]:NEEDS[CommunityTechTree]:FOR[NearFutureElectrical]
 {


### PR DESCRIPTION
The MX-1 reactor is between the MX-0 and MX-2S in terms of cost, mass, power output, and thermal efficiency (power output vs. required cooling), so it doesn't make sense for it to come after the MX-2S in the tech tree.  The MX-2S is intentionally earlier than the MX-2L, so it should stay where it is, but it seems reasonable to move the MX-1 down one step, to be alongside the MX-2S and a step above the MX-0.

(For future reference: the MX-1 and MX-2S reactor positioning are discussed in [this forum post](https://forum.kerbalspaceprogram.com/index.php?/topic/155465-110x-near-future-technologies-all-110-nfa-returns/&do=findComment&comment=3876707).)